### PR TITLE
Use CPM dependent on zyn version

### DIFF
--- a/src/Effects/EffectMgr.cpp
+++ b/src/Effects/EffectMgr.cpp
@@ -547,13 +547,13 @@ void EffectMgr::out(float *smpsl, float *smpsr)
     //Insertion effect
     if(insertion != 0) {
         float v1, v2;
-        
-    if((synth.compatibility&MSK_CONSTPOWDRYWET)==MSK_CONSTPOWDRYWET)
+
+    if(constPowerMixing)
     {
         v1 = sqrtf(1.0f-volume);
         v2 = sqrtf(volume);
-    } else
-    {
+    } else {
+        // compatibility mode
         if(volume < 0.5f) {
             v1 = 1.0f;
             v2 = volume * 2.0f;
@@ -659,6 +659,8 @@ void EffectMgr::add2XML(XMLwrapper& xml)
 
 void EffectMgr::getfromXML(XMLwrapper& xml)
 {
+    constPowerMixing = xml.fileversion() >= version_type(3,0,7);
+
     changeeffect(xml.getpar127("type", geteffect()));
 
     if(!geteffect())

--- a/src/Effects/EffectMgr.h
+++ b/src/Effects/EffectMgr.h
@@ -18,7 +18,6 @@
 
 #include "../Params/FilterParams.h"
 #include "../Params/Presets.h"
-#include "../globals.h"
 
 namespace zyn {
 
@@ -32,7 +31,7 @@ class EffectMgr:public Presets
 {
     public:
         EffectMgr(Allocator &alloc, const SYNTH_T &synth, const bool insertion_,
-              const AbsTime *time_ = nullptr, Sync *sync_ = nullptr);
+              const AbsTime *time_ = nullptr);
         ~EffectMgr() override;
 
         void paste(EffectMgr &e);
@@ -74,11 +73,10 @@ class EffectMgr:public Presets
         int     nefx;
         Effect *efx;
         const AbsTime *time;
-        Sync *sync;
-
+        
         int numerator;
         int denominator;
-
+        
     private:
 
         //Parameters Prior to initialization
@@ -112,8 +110,8 @@ class EffectMgr:public Presets
         bool dryonly;
         Allocator &memory;
         const SYNTH_T &synth;
-
-
+        bool constPowerMixing = true;
+        
 };
 
 }

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -47,7 +47,6 @@ static const rtosc::Ports ports = {
     rParamI(cfg.SoundBufferSize, "Size of processed audio buffer"),
     rParamI(cfg.OscilSize, "Size Of Oscillator Wavetable"),
     rToggle(cfg.SwapStereo, "Swap Left And Right Channels"),
-    rToggle(cfg.ConstPowerMixing, "use 3dB sqrt const power mixing for x-fading and panning"),
     rToggle(cfg.AudioOutputCompressor, "Apply Compressor to Audio Output"),
     rToggle(cfg.BankUIAutoClose, "Automatic Closing of BackUI After Patch Selection"),
     rParamI(cfg.GzipCompression, "Level of Gzip Compression For Save Files"),
@@ -196,8 +195,6 @@ void Config::init()
     cfg.SoundBufferSize = 256;
     cfg.OscilSize  = 1024;
     cfg.SwapStereo = 0;
-    cfg.ConstPowerMixing = 0;
-    cfg.ConstPowerPanning = 0;
     cfg.AudioOutputCompressor = 0;
 
     cfg.oss_devs.linux_wave_out = new char[MAX_STRING_SIZE];
@@ -327,14 +324,6 @@ void Config::readConfig(const char *filename)
                                        cfg.SwapStereo,
                                        0,
                                        1);
-        cfg.ConstPowerMixing = xmlcfg.getpar("const_power_mixing",
-                                       cfg.ConstPowerMixing,
-                                       0,
-                                       1);
-        cfg.ConstPowerMixing = xmlcfg.getpar("const_power_panning",
-                                       cfg.ConstPowerPanning,
-                                       0,
-                                       1);
         cfg.AudioOutputCompressor = xmlcfg.getpar("audio_output_compressor",
                                        cfg.AudioOutputCompressor,
                                        0,
@@ -435,8 +424,6 @@ void Config::saveConfig(const char *filename) const
     xmlcfg->addpar("sound_buffer_size", cfg.SoundBufferSize);
     xmlcfg->addpar("oscil_size", cfg.OscilSize);
     xmlcfg->addpar("swap_stereo", cfg.SwapStereo);
-    xmlcfg->addpar("const_power_mixing", cfg.ConstPowerMixing);
-    xmlcfg->addpar("const_power_panning", cfg.ConstPowerPanning);
     xmlcfg->addpar("audio_output_compressor", cfg.AudioOutputCompressor);
     xmlcfg->addpar("bank_window_auto_close", cfg.BankUIAutoClose);
 

--- a/src/Misc/Config.h
+++ b/src/Misc/Config.h
@@ -41,7 +41,7 @@ class Config
 
         struct {
             oss_devs_t oss_devs;
-            int   SampleRate, SoundBufferSize, OscilSize, SwapStereo, ConstPowerMixing, ConstPowerPanning;
+            int   SampleRate, SoundBufferSize, OscilSize, SwapStereo;
             bool  AudioOutputCompressor;
             int   WindowsWaveOutId, WindowsMidiInId;
             int   BankUIAutoClose;

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -282,6 +282,8 @@ class Master
 
         Value_Smoothing_Filter smoothing_part_l[NUM_MIDI_PARTS];
         Value_Smoothing_Filter smoothing_part_r[NUM_MIDI_PARTS];
+
+        bool constPowerMixing = true;
 };
 
 class master_dispatcher_t : public rtosc::savefile_dispatcher_t

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -667,16 +667,16 @@ bool Part::NoteOnInternal(note_t note,
             if(item.Padenabled)
                 notePool.insertNote(note, sendto,
                         {memory.alloc<ADnote>(kit[i].adpars, pars,
-                            wm, (pre+"kit"+i+"/adpars/").c_str), 0, i},
+                            wm, (pre+"kit"+i+"/adpars/").c_str, constPowerMixing), 0, i},
                                     portamento_realtime);
             if(item.Psubenabled)
                 notePool.insertNote(note, sendto,
-                        {memory.alloc<SUBnote>(kit[i].subpars, pars, wm, (pre+"kit"+i+"/subpars/").c_str), 1, i},
+                        {memory.alloc<SUBnote>(kit[i].subpars, pars, wm, (pre+"kit"+i+"/subpars/").c_str, constPowerMixing), 1, i},
                                     portamento_realtime);
             if(item.Ppadenabled)
                 notePool.insertNote(note, sendto,
                         {memory.alloc<PADnote>(kit[i].padpars, pars, interpolation, wm,
-                            (pre+"kit"+i+"/padpars/").c_str), 2, i},
+                            (pre+"kit"+i+"/padpars/").c_str, constPowerMixing), 2, i},
                                     portamento_realtime);
         } catch (std::bad_alloc & ba) {
             std::cerr << "dropped new note: " << ba.what() << std::endl;
@@ -1381,6 +1381,7 @@ void Part::monomemClear(void)
 
 void Part::getfromXMLinstrument(XMLwrapper& xml)
 {
+    constPowerMixing = xml.fileversion() >= version_type(3,0,7);
     if(xml.enterbranch("INFO")) {
         xml.getparstr("name", (char *)Pname, PART_MAX_NAME_LEN);
         xml.getparstr("author", (char *)info.Pauthor, MAX_INFO_TEXT_SIZE);
@@ -1473,6 +1474,7 @@ void Part::getfromXMLinstrument(XMLwrapper& xml)
 
 void Part::getfromXML(XMLwrapper& xml)
 {
+    constPowerMixing = xml.fileversion() >= version_type(3,0,7);
     Penabled = xml.getparbool("enabled", Penabled);
     if (xml.hasparreal("volume")) {
         setVolumedB(xml.getparreal("volume", Volume));

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -233,6 +233,7 @@ class Part
         const AbsTime &time;
         Sync* sync;
         const int &gzip_compression, &interpolation;
+        bool constPowerMixing = true;
 };
 
 }

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -32,8 +32,8 @@
 
 namespace zyn {
 ADnote::ADnote(ADnoteParameters *pars_, const SynthParams &spars,
-        WatchManager *wm, const char *prefix)
-    :SynthNote(spars), watch_be4_add(wm, prefix, "noteout/be4_mix"), watch_after_add(wm,prefix,"noteout/after_mix"),
+               WatchManager *wm, const char *prefix, bool constPowerMixing)
+    :SynthNote(spars, constPowerMixing), watch_be4_add(wm, prefix, "noteout/be4_mix"), watch_after_add(wm,prefix,"noteout/after_mix"),
     watch_punch(wm, prefix, "noteout/punch"), watch_legato(wm, prefix, "noteout/legato"), pars(*pars_)
 {
     memory.beginTransaction();
@@ -1843,13 +1843,14 @@ int ADnote::noteout(float *outl, float *outr)
                     stereo_pos = 0.0f;
                 float panning = (stereo_pos + 1.0f) * 0.5f;
                 float lvol, rvol;
-                if((synth.compatibility&MSK_CONSTPOWPAN)==MSK_CONSTPOWPAN)
+                if(constPowerMixing())
                 {
                     lvol = sqrtf(1.0f - panning);
                     rvol = sqrtf(panning);
                 }
                 else
                 {
+                    // compatibility mode
                     lvol = (1.0f - panning) * 2.0f;
                     if(lvol > 1.0f)
                         lvol = 1.0f;

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -39,7 +39,8 @@ class ADnote:public SynthNote
          * @param pars Note Parameters
          * @param spars Synth Engine Agnostic Parameters*/
         ADnote(ADnoteParameters *pars, const SynthParams &spars,
-                WatchManager *wm=0, const char *prefix=0);
+                WatchManager *wm=0, const char *prefix=0,
+                bool constPowerMixing = true);
         /**Destructor*/
         ~ADnote();
 

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -28,8 +28,8 @@ namespace zyn {
 
 PADnote::PADnote(const PADnoteParameters *parameters,
                  const SynthParams &pars, const int& interpolation, WatchManager *wm,
-                 const char *prefix)
-    :SynthNote(pars),
+                 const char *prefix, bool constPowerMixing)
+    :SynthNote(pars, constPowerMixing),
     watch_int(wm, prefix, "noteout/after_interpolation"), watch_punch(wm, prefix, "noteout/after_punch"),
     watch_amp_int(wm, prefix, "noteout/after_amp_interpolation"), watch_legato(wm, prefix, "noteout/after_legato"),
      pars(*parameters),interpolation(interpolation)
@@ -409,14 +409,13 @@ int PADnote::noteout(float *outl, float *outr)
         }
 
     watch_punch(outl,synth.buffersize);
-    // compute panning factors 
+    // compute panning factors
     float pan_l, pan_r;
-    if((synth.compatibility&MSK_CONSTPOWPAN)==MSK_CONSTPOWPAN)
+    if(constPowerMixing())
     {   // sqrt 3dB constant power mode
         pan_l = sqrtf(1.0f - NoteGlobalPar.Panning);
         pan_r = sqrtf(NoteGlobalPar.Panning);
-    } else 
-    {   // compatibility mode
+    } else {   // compatibility mode
         pan_l = (1.0f - NoteGlobalPar.Panning);
         pan_r = (NoteGlobalPar.Panning);
     }

--- a/src/Synth/PADnote.h
+++ b/src/Synth/PADnote.h
@@ -25,7 +25,7 @@ class PADnote:public SynthNote
 {
     public:
         PADnote(const PADnoteParameters *parameters, const SynthParams &pars,
-                const int &interpolation, WatchManager *wm=0, const char *prefix=0);
+                const int &interpolation, WatchManager *wm=0, const char *prefix=0, bool constPowerMixing = true);
         ~PADnote();
 
         SynthNote *cloneLegato(void);

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -37,8 +37,8 @@
 namespace zyn {
 
 SUBnote::SUBnote(const SUBnoteParameters *parameters, const SynthParams &spars,
-    WatchManager *wm, const char *prefix) :
-    SynthNote(spars),
+    WatchManager *wm, const char *prefix, bool constPowerMixing) :
+    SynthNote(spars, constPowerMixing),
     watch_filter(wm, prefix, "noteout/filter"), watch_amp_int(wm,prefix,"noteout/amp_int"),
     watch_legato(wm, prefix, "noteout/legato"),
     pars(*parameters),
@@ -579,13 +579,14 @@ int SUBnote::noteout(float *outl, float *outr)
         }
         firsttick = false;
     }
-    // compute panning factors 
+    // compute panning factors
     float pan_l, pan_r;
-    if((synth.compatibility&MSK_CONSTPOWPAN)==MSK_CONSTPOWPAN)
+    if(constPowerMixing())
     {   // sqrt 3dB constant power mode
         pan_l = sqrtf(1.0f - panning);
         pan_r = sqrtf(panning);
-    } else 
+    }
+    else
     {   // compatibility mode
         pan_l = (1.0f - panning);
         pan_r = (panning);
@@ -606,7 +607,6 @@ int SUBnote::noteout(float *outl, float *outr)
             outl[i] *= newamplitude * pan_l;
             outr[i] *= newamplitude * pan_r;
         }
-        
 
     watch_amp_int(outl,synth.buffersize);
     oldamplitude = newamplitude;

--- a/src/Synth/SUBnote.h
+++ b/src/Synth/SUBnote.h
@@ -24,7 +24,7 @@ class SUBnote:public SynthNote
 {
     public:
         SUBnote(const SUBnoteParameters *parameters, const SynthParams &pars,
-                WatchManager *wm = 0, const char *prefix = 0);
+                WatchManager *wm = 0, const char *prefix = 0, bool constPowerMixing = true);
         ~SUBnote();
 
         SynthNote *cloneLegato(void);

--- a/src/Synth/SynthNote.cpp
+++ b/src/Synth/SynthNote.cpp
@@ -19,10 +19,11 @@
 
 namespace zyn {
 
-SynthNote::SynthNote(const SynthParams &pars)
+SynthNote::SynthNote(const SynthParams &pars, bool constPowerMixing)
     :memory(pars.memory),
     legato(pars.synth, pars.velocity, pars.portamento,
-            pars.note_log2_freq, pars.quiet, pars.seed), ctl(pars.ctl), synth(pars.synth), time(pars.time)
+            pars.note_log2_freq, pars.quiet, pars.seed), ctl(pars.ctl), synth(pars.synth), time(pars.time),
+            m_constPowerMixing(constPowerMixing)
 {}
 
 SynthNote::Legato::Legato(const SYNTH_T &synth_, float vel,

--- a/src/Synth/SynthNote.h
+++ b/src/Synth/SynthNote.h
@@ -46,7 +46,7 @@ struct LegatoParams
 class SynthNote
 {
     public:
-        SynthNote(const SynthParams &pars);
+        SynthNote(const SynthParams &pars, bool constPowerMixing);
         virtual ~SynthNote() {}
 
         /**Compute Output Samples
@@ -81,6 +81,8 @@ class SynthNote
         /* Random numbers with own seed */
         float getRandomFloat();
         prng_t getRandomUint();
+
+        bool constPowerMixing() const { return m_constPowerMixing; }
 
         //Realtime Safe Memory Allocator For notes
         class Allocator  &memory;
@@ -133,6 +135,8 @@ class SynthNote
         const AbsTime    &time;
         WatchManager     *wm;
         smooth_float     filtercutoff_relfreq;
+    private:
+        bool m_constPowerMixing;
 };
 
 }

--- a/src/Tests/AdNoteTest.cpp
+++ b/src/Tests/AdNoteTest.cpp
@@ -140,7 +140,7 @@ class AdNoteTest
             test_freq_log2 = log2f(440.0f) + (50.0 - 69.0f) / 12.0f;
             SynthParams pars{memory, *controller, *synth, *time, 120, 0, test_freq_log2, false, prng()};
 
-            note = new ADnote(defaultPreset, pars,w);
+            note = new ADnote(defaultPreset, pars, w, nullptr, false /* compatibility mode */);
 
         }
 

--- a/src/Tests/PadNoteTest.cpp
+++ b/src/Tests/PadNoteTest.cpp
@@ -111,7 +111,7 @@ class PadNoteTest
             test_freq_log2 = log2f(440.0f) + (50.0 - 69.0f) / 12.0f;
             SynthParams pars_{memory, *controller, *synth, *time, 120, 0, test_freq_log2, false, prng()};
 
-            note = new PADnote(pars, pars_, interpolation);
+            note = new PADnote(pars, pars_, interpolation, nullptr, nullptr, false /* compatibility mode */);
         }
 
         void tearDown() {
@@ -161,9 +161,9 @@ class PadNoteTest
             note->releasekey();
 
             TS_ASSERT(!tr->hasNext());
-            
-            
-            TS_ASSERT((synth->compatibility&MSK_CONSTPOWPAN)!=MSK_CONSTPOWPAN);
+
+
+            TS_ASSERT(!note->constPowerMixing());
             w->add_watch("noteout");
             note->noteout(outL, outR);
             sampleCount += synth->buffersize;

--- a/src/Tests/SubNoteTest.cpp
+++ b/src/Tests/SubNoteTest.cpp
@@ -84,7 +84,7 @@ class SubNoteTest
             test_freq_log2 = log2f(440.0f) + (50.0 - 69.0f) / 12.0f;
 
             SynthParams pars{memory, *controller, *synth, *time, 120, 0, test_freq_log2, false, prng()};
-            note = new SUBnote(defaultPreset, pars, w);
+            note = new SUBnote(defaultPreset, pars, w, nullptr, false /* compatibility mode */);
             this->pars = defaultPreset;
         }
 
@@ -125,8 +125,8 @@ class SubNoteTest
 
             TS_ASSERT(!tr->hasNext());
             w->add_watch("noteout/filter");
-            
-            TS_ASSERT((synth->compatibility&MSK_CONSTPOWPAN)!=MSK_CONSTPOWPAN);
+
+            TS_ASSERT(!note->constPowerMixing());
 
             note->noteout(outL, outR);
             sampleCount += synth->buffersize;

--- a/src/Tests/UnisonTest.cpp
+++ b/src/Tests/UnisonTest.cpp
@@ -95,7 +95,7 @@ class UnisonTest
             params->VoicePar[0].Unison_invert_phase     = f;
 
             SynthParams pars{memory, *controller, *synth, *time, 120, 0, test_freq_log2, false, prng()};
-            ADnote* note = new ADnote(params, pars);
+            ADnote* note = new ADnote(params, pars, nullptr, nullptr, false /* compatibility mode */);
             note->noteout(outL, outR);
             TS_ASSERT_DELTA(values[0], outL[80], 2.5e-4);
             printf("{%f,", outL[80]);

--- a/src/globals.h
+++ b/src/globals.h
@@ -79,9 +79,6 @@ class  Sync;
 typedef float fftwf_real;
 typedef std::complex<fftwf_real> fft_t;
 
-#define MSK_CONSTPOWPAN     0b00000001
-#define MSK_CONSTPOWDRYWET  0b00000010
-
 /**
  * The number of harmonics of additive synth
  * This must be smaller than OSCIL_SIZE/2
@@ -320,7 +317,7 @@ public:
 struct SYNTH_T {
 
     SYNTH_T(void)
-        :samplerate(44100), buffersize(256), oscilsize(1024), compatibility(0)
+        :samplerate(44100), buffersize(256), oscilsize(1024)
     {
         alias(false);
     }
@@ -352,15 +349,6 @@ struct SYNTH_T {
      * Increase this => CPU requirements gets high (only at start of the note)
      */
     int oscilsize;
-    
-    
-    /**
-     * compatibility mask
-     * Bit0 (MSK_CONSTPOWDRYWET) 1: constant power dry/wet mixing active 0: compatibility mode
-     * Bit1 (MSK_CONSTPOWMIX) 1: constant power panning active 0: compatibility mode
-     * Bit2 (BIT_???) reserverd
-     */
-    int compatibility;
 
     //Alias for above terms
     float samplerate_f;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,6 @@ MiddleWare *middleware;
 
 Master   *master;
 int       swaplr = 0; //1 for left-right swapping
-int       cpowmix = 0; //1 for const power mixing
 bool      compr = false; // enables output audio compressor
 
 // forward declarations of namespace zyn
@@ -243,10 +242,6 @@ int main(int argc, char *argv[])
     synth.buffersize = config.cfg.SoundBufferSize;
     synth.oscilsize  = config.cfg.OscilSize;
     swaplr = config.cfg.SwapStereo;
-    if (config.cfg.ConstPowerPanning)
-        synth.compatibility |= MSK_CONSTPOWPAN;
-    if (config.cfg.ConstPowerMixing)
-        synth.compatibility |= MSK_CONSTPOWDRYWET;
     compr = config.cfg.AudioOutputCompressor;
 
     Nio::preferredSampleRate(synth.samplerate);

--- a/src/zyn-version.h.in
+++ b/src/zyn-version.h.in
@@ -61,6 +61,11 @@ public:
         return v_strcmp(other, 0) < 0;
     }
 
+    constexpr bool operator>=(const version_type& other) const
+    {
+        return !operator<(other);
+    }
+
     //! prints version as <major>.<minor>.<revision>
     friend std::ostream& operator<< (std::ostream& os,
                                      const version_type& v);


### PR DESCRIPTION
The rtosc update is needed to run CMake on my PC (avoid warnings).
The rest is obvious.